### PR TITLE
Add 'tested with...' for linux and windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,20 @@ sudo apt install libwebkit2gtk-4.1-dev
 sudo apt install libatk1.0-dev
 ```
 
+#### Tested on Ubuntu 24.04 with:
+- npm 9.2.0
+- node 18.19.1
+- rustc 1.83.0 -- `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`
+
+#### Tested on Windows 11 with:
+- npm 10.7.0
+- node 18.20.4
+- rustc 1.83.0 -- See https://www.rust-lang.org/tools/install
+- cmake 3.31.0 -- See https://cmake.org/download/
+
 ## Running in dev mode
 ```
 npm install
 npm run tauri dev
 ```
+


### PR DESCRIPTION
# Added 'tested with' to ReadMe as follows (including windows cmake info): 

#### Tested on Ubuntu 24.04 with:
- npm 9.2.0
- node 18.19.1
- rustc 1.83.0 -- `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`

#### Tested on Windows 11 with:
- npm 10.7.0
- node 18.20.4
- rustc 1.83.0 -- See https://www.rust-lang.org/tools/install
- cmake 3.31.0 -- See https://cmake.org/download/