### PR TITLE
Windows - cmake v3 is required.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ sudo apt install libatk1.0-dev
 - npm 10.7.0
 - node 18.20.4
 - rustc 1.83.0 -- See https://www.rust-lang.org/tools/install
-- cmake 3.31.0 -- See https://cmake.org/download/
+- cmake 3.31.0 -- _Version 3 is required._ See https://cmake.org/download/
 
 ## Running in dev mode
 ```


### PR DESCRIPTION
Added readme clarification that for Windows version ̌3 of cmake is required:

![image](https://github.com/user-attachments/assets/79a4ae8b-a096-4c45-8152-75373f033d65)
