### PR TITLE
Remove space char from Awami Nastaliq unicode ranges

### DIFF
--- a/webfonts/_webfonts.css
+++ b/webfonts/_webfonts.css
@@ -22,6 +22,8 @@
 @import url("pankosmia-Roboto_Medium.css");
 @import url("pankosmia-Roboto_Thin.css");
 
+@import url("pankosmia-Awami_Nastaliq_for_Graphite_Test.css");
+
 .fonts-Pankosmia-EzraSILPankosmia-PadaukPankosmia-AwamiNastaliqPankosmia-NotoNastaliqUrduPankosmia-AndikaPankosmia-GentiumPlus {font-family: 'Pankosmia-Ezra SIL', 'Pankosmia-Padauk', 'Pankosmia-Awami Nastaliq', 'Pankosmia-Noto Nastaliq Urdu', 'Pankosmia-Andika', 'Pankosmia-Gentium Plus';}
 .fonts-Pankosmia-EzraSILPankosmia-PadaukBookPankosmia-AwamiNastaliqPankosmia-NotoNastaliqUrduPankosmia-AndikaPankosmia-GentiumPlus {font-family: 'Pankosmia-Ezra SIL', 'Pankosmia-Padauk Book', 'Pankosmia-Awami Nastaliq', 'Pankosmia-Noto Nastaliq Urdu', 'Pankosmia-Andika', 'Pankosmia-Gentium Plus';}
 .fonts-Pankosmia-EzraSILPankosmia-AwamiNastaliqPankosmia-NotoNastaliqUrduPankosmia-AndikaPankosmia-GentiumPlus {font-family: 'Pankosmia-Ezra SIL', 'Pankosmia-Awami Nastaliq', 'Pankosmia-Noto Nastaliq Urdu', 'Pankosmia-Andika', 'Pankosmia-Gentium Plus';}

--- a/webfonts/pankosmia-Awami_Nastaliq.css
+++ b/webfonts/pankosmia-Awami_Nastaliq.css
@@ -9,7 +9,7 @@
     font-style: normal;
     font-weight: normal; /* 400 Normal (Regular) */
     src: url(./awami/AwamiNastaliq-Regular.woff2);
-    unicode-range: U+0020, U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
+    unicode-range: U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
     font-display: swap;
     font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
     -moz-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
@@ -22,7 +22,7 @@
     font-style: italic; /* Doesn't exist */
     font-weight: normal; /* 400 Normal (Regular) */
     src: url(./awami/AwamiNastaliq-Regular.woff2);
-    unicode-range: U+0020, U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
+    unicode-range: U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
     font-display: swap;
     font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
     -moz-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
@@ -35,7 +35,7 @@
     font-style: normal;
     font-weight: bold; /* 700 */
     src: url(./awami/AwamiNastaliq-Bold.woff2);
-    unicode-range: U+0020, U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
+    unicode-range: U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
     font-display: swap;
     font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
     -moz-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
@@ -48,7 +48,7 @@
     font-style: italic; /* Doesn't exist */
     font-weight: bold; /* 700 */
     src: url(./awami/AwamiNastaliq-Bold.woff2);
-    unicode-range: U+0020, U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
+    unicode-range: U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
     font-display: swap;
     font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
     -moz-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;

--- a/webfonts/pankosmia-Awami_Nastaliq_Extra_Bold.css
+++ b/webfonts/pankosmia-Awami_Nastaliq_Extra_Bold.css
@@ -9,7 +9,7 @@
     font-style: normal;
     font-weight: normal; /* This is really Semi Bold (Demi Bold) - 600 */
     src: url(./awami/AwamiNastaliq-SemiBold.woff2);
-    unicode-range: U+0020, U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
+    unicode-range: U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
     font-display: swap;
     font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
     -moz-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
@@ -22,7 +22,7 @@
     font-style: italic; /* Doesn't exist */
     font-weight: normal; /* This is really Semi Bold (Demi Bold) - 600 */
     src: url(./awami/AwamiNastaliq-SemiBold.woff2);
-    unicode-range: U+0020, U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
+    unicode-range: U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
     font-display: swap;
     font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
     -moz-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
@@ -35,7 +35,7 @@
     font-style: normal;
     font-weight: bold; /* This is really Extra Bold (Ultra Bold) - 800 */
     src: url(./awami/AwamiNastaliq-ExtraBold.woff2);
-    unicode-range: U+0020, U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
+    unicode-range: U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
     font-display: swap;
     font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
     -moz-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
@@ -48,7 +48,7 @@
     font-style: italic; /* Doesn't exist */
     font-weight: bold; /* This is really Extra Bold (Ultra Bold) - 800 */
     src: url(./awami/AwamiNastaliq-ExtraBold.woff2);
-    unicode-range: U+0020, U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
+    unicode-range: U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
     font-display: swap;
     font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
     -moz-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;

--- a/webfonts/pankosmia-Awami_Nastaliq_Medium.css
+++ b/webfonts/pankosmia-Awami_Nastaliq_Medium.css
@@ -9,7 +9,7 @@
     font-style: normal;
     font-weight: normal; /* 400 Normal (Regular) */
     src: url(./awami/AwamiNastaliq-Regular.woff2);
-    unicode-range: U+0020, U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
+    unicode-range: U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
     font-display: swap;
     font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
     -moz-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
@@ -22,7 +22,7 @@
     font-style: italic; /* Doesn't exist */
     font-weight: normal; /* 400 Normal (Regular) */
     src: url(./awami/AwamiNastaliq-Regular.woff2);
-    unicode-range: U+0020, U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
+    unicode-range: U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
     font-display: swap;
     font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
     -moz-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
@@ -35,7 +35,7 @@
     font-weight: normal; /* 400 Normal (Regular) */
     font-weight: bold; /* This is really Medium - 500 */
     src: url(./awami/AwamiNastaliq-Medium.woff2);
-    unicode-range: U+0020, U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
+    unicode-range: U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
     font-display: swap;
     font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
     -moz-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
@@ -48,7 +48,7 @@
     font-style: italic; /* Doesn't exist */
     font-weight: bold; /* 700 */
     src: url(./awami/AwamiNastaliq-Medium.woff2);
-    unicode-range: U+0020, U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
+    unicode-range: U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
     font-display: swap;
     font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
     -moz-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;

--- a/webfonts/pankosmia-Awami_Nastaliq_Semi_Bold.css
+++ b/webfonts/pankosmia-Awami_Nastaliq_Semi_Bold.css
@@ -9,7 +9,7 @@
     font-style: normal;
     font-weight: normal; /* 400 Normal (Regular) */
     src: url(./awami/AwamiNastaliq-Regular.woff2);
-    unicode-range: U+0020, U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
+    unicode-range: U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
     font-display: swap;
     font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
     -moz-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
@@ -22,7 +22,7 @@
     font-style: italic; /* Doesn't exist */
     font-weight: normal; /* 400 Normal (Regular) */
     src: url(./awami/AwamiNastaliq-Regular.woff2);
-    unicode-range: U+0020, U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
+    unicode-range: U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
     font-display: swap;
     font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
     -moz-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
@@ -35,7 +35,7 @@
     font-style: normal;
     font-weight: bold; /* This is really Semi Bold (Demi Bold) - 600 */
     src: url(./awami/AwamiNastaliq-SemiBold.woff2);
-    unicode-range: U+0020, U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
+    unicode-range: U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
     font-display: swap;
     font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
     -moz-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
@@ -48,7 +48,7 @@
     font-style: italic; /* Doesn't exist */
     font-weight: bold; /* 700 */
     src: url(./awami/AwamiNastaliq-SemiBold.woff2);
-    unicode-range: U+0020, U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
+    unicode-range: U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
     font-display: swap;
     font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
     -moz-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;

--- a/webfonts/pankosmia-Awami_Nastaliq_for_Graphite_Test.css
+++ b/webfonts/pankosmia-Awami_Nastaliq_for_Graphite_Test.css
@@ -1,0 +1,10 @@
+/* Copyright (c) 2000-2024, SIL International (https://www.sil.org/) with Reserved Font Names "Awami" and "SIL".*/
+/* This Font Software is licensed under the SIL Open Font License, Version 1.1. See https://openfontlicense.org/ .*/
+
+@font-face {
+  font-family: 'Pankosmia-Awami Nastaliq for Graphite Test';
+  font-style: normal;
+  font-weight: normal; /* 400 Normal (Regular) */
+  src: url(./awami/AwamiNastaliq-Regular.woff2);
+  font-display: swap;
+}


### PR DESCRIPTION
- remove U+0020 from Awami Nastaliq unicode ranges to address [space and cursor size](https://github.com/orgs/pankosmia/discussions/5#discussioncomment-12936723)
- Add `Pankosmia-Awami Nastaliq for Graphite Test'