### PR TITLE
Add css font templates

### DIFF
--- a/webfonts/pankosmia-Andika.css
+++ b/webfonts/pankosmia-Andika.css
@@ -7,9 +7,9 @@
   font-style: normal;
   font-weight: normal; /* 400 Normal (Regular) */
   src: url(./andika/Andika-Regular.woff2);
-  font-feature-settings: "smcp" 0, "c2sc" 0, "ss01" 0, "ss13" 0, "ss14" 0, "ss04" 0, "ss05" 0, "cv13" 0, "cv17" 0, "cv28" 0, "cv31" 0, "cv35" 0, "cv37" 0, "cv39" 0, "cv43" 0, "cv44" 0, "cv46" 0, "cv47" 0, "cv49" 0, "cv52" 0, "cv51" 0, "cv55" 0, "cv56" 0, "cv57" 0, "cv62" 0, "cv68" 0, "cv67" 0, "cv20" 0, "cv19" 0, "cv25" 0, "cv69" 0, "cv75" 0, "cv79" 0, "cv76" 0, "cv77" 0, "cv70" 0, "cv71" 0, "cv98" 0, "cv80" 0, "cv81" 0, "cv82" 0, "cv84" 0, "cv90" 0, "cv91" 0, "cv92" 0, "subs" 0, "sups" 0, "frac" 0, "cv10" 0, "cv01" 0, "cv04" 0, "cv06" 0, "cv07" 0;
-  -moz-font-feature-settings: "smcp" 0, "c2sc" 0, "ss01" 0, "ss13" 0, "ss14" 0, "ss04" 0, "ss05" 0, "cv13" 0, "cv17" 0, "cv28" 0, "cv31" 0, "cv35" 0, "cv37" 0, "cv39" 0, "cv43" 0, "cv44" 0, "cv46" 0, "cv47" 0, "cv49" 0, "cv52" 0, "cv51" 0, "cv55" 0, "cv56" 0, "cv57" 0, "cv62" 0, "cv68" 0, "cv67" 0, "cv20" 0, "cv19" 0, "cv25" 0, "cv69" 0, "cv75" 0, "cv79" 0, "cv76" 0, "cv77" 0, "cv70" 0, "cv71" 0, "cv98" 0, "cv80" 0, "cv81" 0, "cv82" 0, "cv84" 0, "cv90" 0, "cv91" 0, "cv92" 0, "subs" 0, "sups" 0, "frac" 0, "cv10" 0, "cv01" 0, "cv04" 0, "cv06" 0, "cv07" 0;
-  -webkit-font-feature-settings: "smcp" 0, "c2sc" 0, "ss01" 0, "ss13" 0, "ss14" 0, "ss04" 0, "ss05" 0, "cv13" 0, "cv17" 0, "cv28" 0, "cv31" 0, "cv35" 0, "cv37" 0, "cv39" 0, "cv43" 0, "cv44" 0, "cv46" 0, "cv47" 0, "cv49" 0, "cv52" 0, "cv51" 0, "cv55" 0, "cv56" 0, "cv57" 0, "cv62" 0, "cv68" 0, "cv67" 0, "cv20" 0, "cv19" 0, "cv25" 0, "cv69" 0, "cv75" 0, "cv79" 0, "cv76" 0, "cv77" 0, "cv70" 0, "cv71" 0, "cv98" 0, "cv80" 0, "cv81" 0, "cv82" 0, "cv84" 0, "cv90" 0, "cv91" 0, "cv92" 0, "subs" 0, "sups" 0, "frac" 0, "cv10" 0, "cv01" 0, "cv04" 0, "cv06" 0, "cv07" 0;
+  font-feature-settings: %%FONTFEATURES%%;
+  -moz-font-feature-settings: %%FONTFEATURES%%;
+  -webkit-font-feature-settings: %%FONTFEATURES%%;
 }
 
 /* italic */
@@ -18,9 +18,9 @@
   font-style: italic;
   font-weight: normal; /* 400 Normal (Regular) */
   src: url(./andika/Andika-Italic.woff2);
-  font-feature-settings: "smcp" 0, "c2sc" 0, "ss01" 0, "ss13" 0, "ss14" 0, "ss04" 0, "ss05" 0, "cv13" 0, "cv17" 0, "cv28" 0, "cv31" 0, "cv35" 0, "cv37" 0, "cv39" 0, "cv43" 0, "cv44" 0, "cv46" 0, "cv47" 0, "cv49" 0, "cv52" 0, "cv51" 0, "cv55" 0, "cv56" 0, "cv57" 0, "cv62" 0, "cv68" 0, "cv67" 0, "cv20" 0, "cv19" 0, "cv25" 0, "cv69" 0, "cv75" 0, "cv79" 0, "cv76" 0, "cv77" 0, "cv70" 0, "cv71" 0, "cv98" 0, "cv80" 0, "cv81" 0, "cv82" 0, "cv84" 0, "cv90" 0, "cv91" 0, "cv92" 0, "subs" 0, "sups" 0, "frac" 0, "cv10" 0, "cv01" 0, "cv04" 0, "cv06" 0, "cv07" 0;
-  -moz-font-feature-settings: "smcp" 0, "c2sc" 0, "ss01" 0, "ss13" 0, "ss14" 0, "ss04" 0, "ss05" 0, "cv13" 0, "cv17" 0, "cv28" 0, "cv31" 0, "cv35" 0, "cv37" 0, "cv39" 0, "cv43" 0, "cv44" 0, "cv46" 0, "cv47" 0, "cv49" 0, "cv52" 0, "cv51" 0, "cv55" 0, "cv56" 0, "cv57" 0, "cv62" 0, "cv68" 0, "cv67" 0, "cv20" 0, "cv19" 0, "cv25" 0, "cv69" 0, "cv75" 0, "cv79" 0, "cv76" 0, "cv77" 0, "cv70" 0, "cv71" 0, "cv98" 0, "cv80" 0, "cv81" 0, "cv82" 0, "cv84" 0, "cv90" 0, "cv91" 0, "cv92" 0, "subs" 0, "sups" 0, "frac" 0, "cv10" 0, "cv01" 0, "cv04" 0, "cv06" 0, "cv07" 0;
-  -webkit-font-feature-settings: "smcp" 0, "c2sc" 0, "ss01" 0, "ss13" 0, "ss14" 0, "ss04" 0, "ss05" 0, "cv13" 0, "cv17" 0, "cv28" 0, "cv31" 0, "cv35" 0, "cv37" 0, "cv39" 0, "cv43" 0, "cv44" 0, "cv46" 0, "cv47" 0, "cv49" 0, "cv52" 0, "cv51" 0, "cv55" 0, "cv56" 0, "cv57" 0, "cv62" 0, "cv68" 0, "cv67" 0, "cv20" 0, "cv19" 0, "cv25" 0, "cv69" 0, "cv75" 0, "cv79" 0, "cv76" 0, "cv77" 0, "cv70" 0, "cv71" 0, "cv98" 0, "cv80" 0, "cv81" 0, "cv82" 0, "cv84" 0, "cv90" 0, "cv91" 0, "cv92" 0, "subs" 0, "sups" 0, "frac" 0, "cv10" 0, "cv01" 0, "cv04" 0, "cv06" 0, "cv07" 0;
+  font-feature-settings: %%FONTFEATURES%%;
+  -moz-font-feature-settings: %%FONTFEATURES%%;
+  -webkit-font-feature-settings: %%FONTFEATURES%%;
 }
 
 /* bold */
@@ -29,9 +29,9 @@
   font-style: normal;
   font-weight: bold; /* 700 */
   src: url(./andika/Andika-Bold.woff2);
-  font-feature-settings: "smcp" 0, "c2sc" 0, "ss01" 0, "ss13" 0, "ss14" 0, "ss04" 0, "ss05" 0, "cv13" 0, "cv17" 0, "cv28" 0, "cv31" 0, "cv35" 0, "cv37" 0, "cv39" 0, "cv43" 0, "cv44" 0, "cv46" 0, "cv47" 0, "cv49" 0, "cv52" 0, "cv51" 0, "cv55" 0, "cv56" 0, "cv57" 0, "cv62" 0, "cv68" 0, "cv67" 0, "cv20" 0, "cv19" 0, "cv25" 0, "cv69" 0, "cv75" 0, "cv79" 0, "cv76" 0, "cv77" 0, "cv70" 0, "cv71" 0, "cv98" 0, "cv80" 0, "cv81" 0, "cv82" 0, "cv84" 0, "cv90" 0, "cv91" 0, "cv92" 0, "subs" 0, "sups" 0, "frac" 0, "cv10" 0, "cv01" 0, "cv04" 0, "cv06" 0, "cv07" 0;
-  -moz-font-feature-settings: "smcp" 0, "c2sc" 0, "ss01" 0, "ss13" 0, "ss14" 0, "ss04" 0, "ss05" 0, "cv13" 0, "cv17" 0, "cv28" 0, "cv31" 0, "cv35" 0, "cv37" 0, "cv39" 0, "cv43" 0, "cv44" 0, "cv46" 0, "cv47" 0, "cv49" 0, "cv52" 0, "cv51" 0, "cv55" 0, "cv56" 0, "cv57" 0, "cv62" 0, "cv68" 0, "cv67" 0, "cv20" 0, "cv19" 0, "cv25" 0, "cv69" 0, "cv75" 0, "cv79" 0, "cv76" 0, "cv77" 0, "cv70" 0, "cv71" 0, "cv98" 0, "cv80" 0, "cv81" 0, "cv82" 0, "cv84" 0, "cv90" 0, "cv91" 0, "cv92" 0, "subs" 0, "sups" 0, "frac" 0, "cv10" 0, "cv01" 0, "cv04" 0, "cv06" 0, "cv07" 0;
-  -webkit-font-feature-settings: "smcp" 0, "c2sc" 0, "ss01" 0, "ss13" 0, "ss14" 0, "ss04" 0, "ss05" 0, "cv13" 0, "cv17" 0, "cv28" 0, "cv31" 0, "cv35" 0, "cv37" 0, "cv39" 0, "cv43" 0, "cv44" 0, "cv46" 0, "cv47" 0, "cv49" 0, "cv52" 0, "cv51" 0, "cv55" 0, "cv56" 0, "cv57" 0, "cv62" 0, "cv68" 0, "cv67" 0, "cv20" 0, "cv19" 0, "cv25" 0, "cv69" 0, "cv75" 0, "cv79" 0, "cv76" 0, "cv77" 0, "cv70" 0, "cv71" 0, "cv98" 0, "cv80" 0, "cv81" 0, "cv82" 0, "cv84" 0, "cv90" 0, "cv91" 0, "cv92" 0, "subs" 0, "sups" 0, "frac" 0, "cv10" 0, "cv01" 0, "cv04" 0, "cv06" 0, "cv07" 0;
+  font-feature-settings: %%FONTFEATURES%%;
+  -moz-font-feature-settings: %%FONTFEATURES%%;
+  -webkit-font-feature-settings: %%FONTFEATURES%%;
 }
 
 /* bold italic */
@@ -40,7 +40,7 @@
   font-style: italic;
   font-weight: bold; /* 700 */
   src: url(./andika/Andika-BoldItalic.woff2);
-  font-feature-settings: "smcp" 0, "c2sc" 0, "ss01" 0, "ss13" 0, "ss14" 0, "ss04" 0, "ss05" 0, "cv13" 0, "cv17" 0, "cv28" 0, "cv31" 0, "cv35" 0, "cv37" 0, "cv39" 0, "cv43" 0, "cv44" 0, "cv46" 0, "cv47" 0, "cv49" 0, "cv52" 0, "cv51" 0, "cv55" 0, "cv56" 0, "cv57" 0, "cv62" 0, "cv68" 0, "cv67" 0, "cv20" 0, "cv19" 0, "cv25" 0, "cv69" 0, "cv75" 0, "cv79" 0, "cv76" 0, "cv77" 0, "cv70" 0, "cv71" 0, "cv98" 0, "cv80" 0, "cv81" 0, "cv82" 0, "cv84" 0, "cv90" 0, "cv91" 0, "cv92" 0, "subs" 0, "sups" 0, "frac" 0, "cv10" 0, "cv01" 0, "cv04" 0, "cv06" 0, "cv07" 0;
-  -moz-font-feature-settings: "smcp" 0, "c2sc" 0, "ss01" 0, "ss13" 0, "ss14" 0, "ss04" 0, "ss05" 0, "cv13" 0, "cv17" 0, "cv28" 0, "cv31" 0, "cv35" 0, "cv37" 0, "cv39" 0, "cv43" 0, "cv44" 0, "cv46" 0, "cv47" 0, "cv49" 0, "cv52" 0, "cv51" 0, "cv55" 0, "cv56" 0, "cv57" 0, "cv62" 0, "cv68" 0, "cv67" 0, "cv20" 0, "cv19" 0, "cv25" 0, "cv69" 0, "cv75" 0, "cv79" 0, "cv76" 0, "cv77" 0, "cv70" 0, "cv71" 0, "cv98" 0, "cv80" 0, "cv81" 0, "cv82" 0, "cv84" 0, "cv90" 0, "cv91" 0, "cv92" 0, "subs" 0, "sups" 0, "frac" 0, "cv10" 0, "cv01" 0, "cv04" 0, "cv06" 0, "cv07" 0;
-  -webkit-font-feature-settings: "smcp" 0, "c2sc" 0, "ss01" 0, "ss13" 0, "ss14" 0, "ss04" 0, "ss05" 0, "cv13" 0, "cv17" 0, "cv28" 0, "cv31" 0, "cv35" 0, "cv37" 0, "cv39" 0, "cv43" 0, "cv44" 0, "cv46" 0, "cv47" 0, "cv49" 0, "cv52" 0, "cv51" 0, "cv55" 0, "cv56" 0, "cv57" 0, "cv62" 0, "cv68" 0, "cv67" 0, "cv20" 0, "cv19" 0, "cv25" 0, "cv69" 0, "cv75" 0, "cv79" 0, "cv76" 0, "cv77" 0, "cv70" 0, "cv71" 0, "cv98" 0, "cv80" 0, "cv81" 0, "cv82" 0, "cv84" 0, "cv90" 0, "cv91" 0, "cv92" 0, "subs" 0, "sups" 0, "frac" 0, "cv10" 0, "cv01" 0, "cv04" 0, "cv06" 0, "cv07" 0;
+  font-feature-settings: %%FONTFEATURES%%;
+  -moz-font-feature-settings: %%FONTFEATURES%%;
+  -webkit-font-feature-settings: %%FONTFEATURES%%;
 }

--- a/webfonts/pankosmia-Awami_Nastaliq.css
+++ b/webfonts/pankosmia-Awami_Nastaliq.css
@@ -11,9 +11,9 @@
     src: url(./awami/AwamiNastaliq-Regular.woff2);
     unicode-range: U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
     font-display: swap;
-    font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
-    -moz-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
-    -webkit-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
+    font-feature-settings: %%FONTFEATURES%%;
+    -moz-font-feature-settings: %%FONTFEATURES%%;
+    -webkit-font-feature-settings: %%FONTFEATURES%%;
   }
 
   /* italic */
@@ -24,9 +24,9 @@
     src: url(./awami/AwamiNastaliq-Regular.woff2);
     unicode-range: U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
     font-display: swap;
-    font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
-    -moz-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
-    -webkit-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
+    font-feature-settings: %%FONTFEATURES%%;
+    -moz-font-feature-settings: %%FONTFEATURES%%;
+    -webkit-font-feature-settings: %%FONTFEATURES%%;
   }
 
   /* bold */
@@ -37,9 +37,9 @@
     src: url(./awami/AwamiNastaliq-Bold.woff2);
     unicode-range: U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
     font-display: swap;
-    font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
-    -moz-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
-    -webkit-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
+    font-feature-settings: %%FONTFEATURES%%;
+    -moz-font-feature-settings: %%FONTFEATURES%%;
+    -webkit-font-feature-settings: %%FONTFEATURES%%;
   }
 
   /* bold italic*/
@@ -50,8 +50,8 @@
     src: url(./awami/AwamiNastaliq-Bold.woff2);
     unicode-range: U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
     font-display: swap;
-    font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
-    -moz-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
-    -webkit-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
+    font-feature-settings: %%FONTFEATURES%%;
+    -moz-font-feature-settings: %%FONTFEATURES%%;
+    -webkit-font-feature-settings: %%FONTFEATURES%%;
   }
 }

--- a/webfonts/pankosmia-Awami_Nastaliq_Extra_Bold.css
+++ b/webfonts/pankosmia-Awami_Nastaliq_Extra_Bold.css
@@ -11,9 +11,9 @@
     src: url(./awami/AwamiNastaliq-SemiBold.woff2);
     unicode-range: U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
     font-display: swap;
-    font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
-    -moz-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
-    -webkit-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
+    font-feature-settings: %%FONTFEATURES%%;
+    -moz-font-feature-settings: %%FONTFEATURES%%;
+    -webkit-font-feature-settings: %%FONTFEATURES%%;
   }
 
   /* italic */
@@ -24,9 +24,9 @@
     src: url(./awami/AwamiNastaliq-SemiBold.woff2);
     unicode-range: U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
     font-display: swap;
-    font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
-    -moz-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
-    -webkit-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
+    font-feature-settings: %%FONTFEATURES%%;
+    -moz-font-feature-settings: %%FONTFEATURES%%;
+    -webkit-font-feature-settings: %%FONTFEATURES%%;
   }
 
   /* bold */
@@ -37,9 +37,9 @@
     src: url(./awami/AwamiNastaliq-ExtraBold.woff2);
     unicode-range: U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
     font-display: swap;
-    font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
-    -moz-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
-    -webkit-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
+    font-feature-settings: %%FONTFEATURES%%;
+    -moz-font-feature-settings: %%FONTFEATURES%%;
+    -webkit-font-feature-settings: %%FONTFEATURES%%;
   }
 
   /* bold italic */
@@ -50,8 +50,8 @@
     src: url(./awami/AwamiNastaliq-ExtraBold.woff2);
     unicode-range: U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
     font-display: swap;
-    font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
-    -moz-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
-    -webkit-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
+    font-feature-settings: %%FONTFEATURES%%;
+    -moz-font-feature-settings: %%FONTFEATURES%%;
+    -webkit-font-feature-settings: %%FONTFEATURES%%;
   }
 }

--- a/webfonts/pankosmia-Awami_Nastaliq_Medium.css
+++ b/webfonts/pankosmia-Awami_Nastaliq_Medium.css
@@ -11,9 +11,9 @@
     src: url(./awami/AwamiNastaliq-Regular.woff2);
     unicode-range: U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
     font-display: swap;
-    font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
-    -moz-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
-    -webkit-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
+    font-feature-settings: %%FONTFEATURES%%;
+    -moz-font-feature-settings: %%FONTFEATURES%%;
+    -webkit-font-feature-settings: %%FONTFEATURES%%;
   }
 
   /* italic */
@@ -24,9 +24,9 @@
     src: url(./awami/AwamiNastaliq-Regular.woff2);
     unicode-range: U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
     font-display: swap;
-    font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
-    -moz-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
-    -webkit-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
+    font-feature-settings: %%FONTFEATURES%%;
+    -moz-font-feature-settings: %%FONTFEATURES%%;
+    -webkit-font-feature-settings: %%FONTFEATURES%%;
   }
 
   /* bold */
@@ -37,9 +37,9 @@
     src: url(./awami/AwamiNastaliq-Medium.woff2);
     unicode-range: U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
     font-display: swap;
-    font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
-    -moz-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
-    -webkit-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
+    font-feature-settings: %%FONTFEATURES%%;
+    -moz-font-feature-settings: %%FONTFEATURES%%;
+    -webkit-font-feature-settings: %%FONTFEATURES%%;
   }
 
   /* bold italic */
@@ -50,8 +50,8 @@
     src: url(./awami/AwamiNastaliq-Medium.woff2);
     unicode-range: U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
     font-display: swap;
-    font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
-    -moz-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
-    -webkit-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
+    font-feature-settings: %%FONTFEATURES%%;
+    -moz-font-feature-settings: %%FONTFEATURES%%;
+    -webkit-font-feature-settings: %%FONTFEATURES%%;
   }
 }

--- a/webfonts/pankosmia-Awami_Nastaliq_Semi_Bold.css
+++ b/webfonts/pankosmia-Awami_Nastaliq_Semi_Bold.css
@@ -11,9 +11,9 @@
     src: url(./awami/AwamiNastaliq-Regular.woff2);
     unicode-range: U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
     font-display: swap;
-    font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
-    -moz-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
-    -webkit-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
+    font-feature-settings: %%FONTFEATURES%%;
+    -moz-font-feature-settings: %%FONTFEATURES%%;
+    -webkit-font-feature-settings: %%FONTFEATURES%%;
   }
 
   /* italic */
@@ -24,9 +24,9 @@
     src: url(./awami/AwamiNastaliq-Regular.woff2);
     unicode-range: U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
     font-display: swap;
-    font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
-    -moz-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
-    -webkit-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
+    font-feature-settings: %%FONTFEATURES%%;
+    -moz-font-feature-settings: %%FONTFEATURES%%;
+    -webkit-font-feature-settings: %%FONTFEATURES%%;
   }
 
   /* bold */
@@ -37,9 +37,9 @@
     src: url(./awami/AwamiNastaliq-SemiBold.woff2);
     unicode-range: U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
     font-display: swap;
-    font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
-    -moz-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
-    -webkit-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
+    font-feature-settings: %%FONTFEATURES%%;
+    -moz-font-feature-settings: %%FONTFEATURES%%;
+    -webkit-font-feature-settings: %%FONTFEATURES%%;
   }
 
   /* bold italic */
@@ -50,8 +50,8 @@
     src: url(./awami/AwamiNastaliq-SemiBold.woff2);
     unicode-range: U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
     font-display: swap;
-    font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
-    -moz-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
-    -webkit-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 2;
+    font-feature-settings: %%FONTFEATURES%%;
+    -moz-font-feature-settings: %%FONTFEATURES%%;
+    -webkit-font-feature-settings: %%FONTFEATURES%%;
   }
 }

--- a/webfonts/pankosmia-Charis_SIL.css
+++ b/webfonts/pankosmia-Charis_SIL.css
@@ -7,9 +7,9 @@
   font-style: normal;
   font-weight: normal; /* 400 Normal (Regular) */
   src: url(./charis/CharisSIL-Regular.woff2);
-  font-feature-settings: "smcp" 0, "c2sc" 0, "ss01" 0, "ss11" 0, "ss12" 0, "ss04" 0, "ss05" 0, "cv13" 0, "cv17" 0, "cv28" 0, "cv37" 0, "cv43" 0, "cv44" 0, "cv46" 0, "cv47" 0, "cv49" 0, "cv55" 0, "cv57" 0, "cv62" 0, "cv68" 0, "cv20" 0, "cv19" 0, "cv25" 0, "cv69" 0, "cv75" 0, "cv79" 0, "cv76" 0, "cv77" 0, "cv70" 0, "cv71" 0, "cv98" 0, "cv80" 0, "cv81" 0, "cv82" 0, "cv84" 0, "cv90" 0, "cv91" 0, "cv92" 0, "subs" 0, "sups" 0, "frac" 0;
-  -moz-font-feature-settings: "smcp" 0, "c2sc" 0, "ss01" 0, "ss11" 0, "ss12" 0, "ss04" 0, "ss05" 0, "cv13" 0, "cv17" 0, "cv28" 0, "cv37" 0, "cv43" 0, "cv44" 0, "cv46" 0, "cv47" 0, "cv49" 0, "cv55" 0, "cv57" 0, "cv62" 0, "cv68" 0, "cv20" 0, "cv19" 0, "cv25" 0, "cv69" 0, "cv75" 0, "cv79" 0, "cv76" 0, "cv77" 0, "cv70" 0, "cv71" 0, "cv98" 0, "cv80" 0, "cv81" 0, "cv82" 0, "cv84" 0, "cv90" 0, "cv91" 0, "cv92" 0, "subs" 0, "sups" 0, "frac" 0;
-  -webkit-font-feature-settings: "smcp" 0, "c2sc" 0, "ss01" 0, "ss11" 0, "ss12" 0, "ss04" 0, "ss05" 0, "cv13" 0, "cv17" 0, "cv28" 0, "cv37" 0, "cv43" 0, "cv44" 0, "cv46" 0, "cv47" 0, "cv49" 0, "cv55" 0, "cv57" 0, "cv62" 0, "cv68" 0, "cv20" 0, "cv19" 0, "cv25" 0, "cv69" 0, "cv75" 0, "cv79" 0, "cv76" 0, "cv77" 0, "cv70" 0, "cv71" 0, "cv98" 0, "cv80" 0, "cv81" 0, "cv82" 0, "cv84" 0, "cv90" 0, "cv91" 0, "cv92" 0, "subs" 0, "sups" 0, "frac" 0;
+  font-feature-settings: %%FONTFEATURES%%;
+  -moz-font-feature-settings: %%FONTFEATURES%%;
+  -webkit-font-feature-settings: %%FONTFEATURES%%;
 }
 
 /* italic */
@@ -18,9 +18,9 @@
   font-style: italic;
   font-weight: normal; /* 400 Normal (Regular) */
   src: url(./charis/CharisSIL-Italic.woff2);
-  font-feature-settings: "smcp" 0, "c2sc" 0, "ss01" 0, "ss11" 0, "ss12" 0, "ss04" 0, "ss05" 0, "cv13" 0, "cv17" 0, "cv28" 0, "cv37" 0, "cv43" 0, "cv44" 0, "cv46" 0, "cv47" 0, "cv49" 0, "cv55" 0, "cv57" 0, "cv62" 0, "cv68" 0, "cv20" 0, "cv19" 0, "cv25" 0, "cv69" 0, "cv75" 0, "cv79" 0, "cv76" 0, "cv77" 0, "cv70" 0, "cv71" 0, "cv98" 0, "cv80" 0, "cv81" 0, "cv82" 0, "cv84" 0, "cv90" 0, "cv91" 0, "cv92" 0, "subs" 0, "sups" 0, "frac" 0;
-  -moz-font-feature-settings: "smcp" 0, "c2sc" 0, "ss01" 0, "ss11" 0, "ss12" 0, "ss04" 0, "ss05" 0, "cv13" 0, "cv17" 0, "cv28" 0, "cv37" 0, "cv43" 0, "cv44" 0, "cv46" 0, "cv47" 0, "cv49" 0, "cv55" 0, "cv57" 0, "cv62" 0, "cv68" 0, "cv20" 0, "cv19" 0, "cv25" 0, "cv69" 0, "cv75" 0, "cv79" 0, "cv76" 0, "cv77" 0, "cv70" 0, "cv71" 0, "cv98" 0, "cv80" 0, "cv81" 0, "cv82" 0, "cv84" 0, "cv90" 0, "cv91" 0, "cv92" 0, "subs" 0, "sups" 0, "frac" 0;
-  -webkit-font-feature-settings: "smcp" 0, "c2sc" 0, "ss01" 0, "ss11" 0, "ss12" 0, "ss04" 0, "ss05" 0, "cv13" 0, "cv17" 0, "cv28" 0, "cv37" 0, "cv43" 0, "cv44" 0, "cv46" 0, "cv47" 0, "cv49" 0, "cv55" 0, "cv57" 0, "cv62" 0, "cv68" 0, "cv20" 0, "cv19" 0, "cv25" 0, "cv69" 0, "cv75" 0, "cv79" 0, "cv76" 0, "cv77" 0, "cv70" 0, "cv71" 0, "cv98" 0, "cv80" 0, "cv81" 0, "cv82" 0, "cv84" 0, "cv90" 0, "cv91" 0, "cv92" 0, "subs" 0, "sups" 0, "frac" 0;
+  font-feature-settings: %%FONTFEATURES%%;
+  -moz-font-feature-settings: %%FONTFEATURES%%;
+  -webkit-font-feature-settings: %%FONTFEATURES%%;
 }
 
 /* bold */
@@ -29,9 +29,9 @@
   font-style: normal;
   font-weight: bold; /* 700 */
   src: url(./charis/CharisSIL-Bold.woff2);
-  font-feature-settings: "smcp" 0, "c2sc" 0, "ss01" 0, "ss11" 0, "ss12" 0, "ss04" 0, "ss05" 0, "cv13" 0, "cv17" 0, "cv28" 0, "cv37" 0, "cv43" 0, "cv44" 0, "cv46" 0, "cv47" 0, "cv49" 0, "cv55" 0, "cv57" 0, "cv62" 0, "cv68" 0, "cv20" 0, "cv19" 0, "cv25" 0, "cv69" 0, "cv75" 0, "cv79" 0, "cv76" 0, "cv77" 0, "cv70" 0, "cv71" 0, "cv98" 0, "cv80" 0, "cv81" 0, "cv82" 0, "cv84" 0, "cv90" 0, "cv91" 0, "cv92" 0, "subs" 0, "sups" 0, "frac" 0;
-  -moz-font-feature-settings: "smcp" 0, "c2sc" 0, "ss01" 0, "ss11" 0, "ss12" 0, "ss04" 0, "ss05" 0, "cv13" 0, "cv17" 0, "cv28" 0, "cv37" 0, "cv43" 0, "cv44" 0, "cv46" 0, "cv47" 0, "cv49" 0, "cv55" 0, "cv57" 0, "cv62" 0, "cv68" 0, "cv20" 0, "cv19" 0, "cv25" 0, "cv69" 0, "cv75" 0, "cv79" 0, "cv76" 0, "cv77" 0, "cv70" 0, "cv71" 0, "cv98" 0, "cv80" 0, "cv81" 0, "cv82" 0, "cv84" 0, "cv90" 0, "cv91" 0, "cv92" 0, "subs" 0, "sups" 0, "frac" 0;
-  -webkit-font-feature-settings: "smcp" 0, "c2sc" 0, "ss01" 0, "ss11" 0, "ss12" 0, "ss04" 0, "ss05" 0, "cv13" 0, "cv17" 0, "cv28" 0, "cv37" 0, "cv43" 0, "cv44" 0, "cv46" 0, "cv47" 0, "cv49" 0, "cv55" 0, "cv57" 0, "cv62" 0, "cv68" 0, "cv20" 0, "cv19" 0, "cv25" 0, "cv69" 0, "cv75" 0, "cv79" 0, "cv76" 0, "cv77" 0, "cv70" 0, "cv71" 0, "cv98" 0, "cv80" 0, "cv81" 0, "cv82" 0, "cv84" 0, "cv90" 0, "cv91" 0, "cv92" 0, "subs" 0, "sups" 0, "frac" 0;
+  font-feature-settings: %%FONTFEATURES%%;
+  -moz-font-feature-settings: %%FONTFEATURES%%;
+  -webkit-font-feature-settings: %%FONTFEATURES%%;
 }
 
 /* bold italic */
@@ -40,7 +40,7 @@
   font-style: italic;
   font-weight: bold; /* 700 */
   src: url(./charis/CharisSIL-BoldItalic.woff2);
-  font-feature-settings: "smcp" 0, "c2sc" 0, "ss01" 0, "ss11" 0, "ss12" 0, "ss04" 0, "ss05" 0, "cv13" 0, "cv17" 0, "cv28" 0, "cv37" 0, "cv43" 0, "cv44" 0, "cv46" 0, "cv47" 0, "cv49" 0, "cv55" 0, "cv57" 0, "cv62" 0, "cv68" 0, "cv20" 0, "cv19" 0, "cv25" 0, "cv69" 0, "cv75" 0, "cv79" 0, "cv76" 0, "cv77" 0, "cv70" 0, "cv71" 0, "cv98" 0, "cv80" 0, "cv81" 0, "cv82" 0, "cv84" 0, "cv90" 0, "cv91" 0, "cv92" 0, "subs" 0, "sups" 0, "frac" 0;
-  -moz-font-feature-settings: "smcp" 0, "c2sc" 0, "ss01" 0, "ss11" 0, "ss12" 0, "ss04" 0, "ss05" 0, "cv13" 0, "cv17" 0, "cv28" 0, "cv37" 0, "cv43" 0, "cv44" 0, "cv46" 0, "cv47" 0, "cv49" 0, "cv55" 0, "cv57" 0, "cv62" 0, "cv68" 0, "cv20" 0, "cv19" 0, "cv25" 0, "cv69" 0, "cv75" 0, "cv79" 0, "cv76" 0, "cv77" 0, "cv70" 0, "cv71" 0, "cv98" 0, "cv80" 0, "cv81" 0, "cv82" 0, "cv84" 0, "cv90" 0, "cv91" 0, "cv92" 0, "subs" 0, "sups" 0, "frac" 0;
-  -webkit-font-feature-settings: "smcp" 0, "c2sc" 0, "ss01" 0, "ss11" 0, "ss12" 0, "ss04" 0, "ss05" 0, "cv13" 0, "cv17" 0, "cv28" 0, "cv37" 0, "cv43" 0, "cv44" 0, "cv46" 0, "cv47" 0, "cv49" 0, "cv55" 0, "cv57" 0, "cv62" 0, "cv68" 0, "cv20" 0, "cv19" 0, "cv25" 0, "cv69" 0, "cv75" 0, "cv79" 0, "cv76" 0, "cv77" 0, "cv70" 0, "cv71" 0, "cv98" 0, "cv80" 0, "cv81" 0, "cv82" 0, "cv84" 0, "cv90" 0, "cv91" 0, "cv92" 0, "subs" 0, "sups" 0, "frac" 0;
+  font-feature-settings: %%FONTFEATURES%%;
+  -moz-font-feature-settings: %%FONTFEATURES%%;
+  -webkit-font-feature-settings: %%FONTFEATURES%%;
 }

--- a/webfonts/pankosmia-Gentium_Book_Plus.css
+++ b/webfonts/pankosmia-Gentium_Book_Plus.css
@@ -7,9 +7,9 @@
   font-style: normal;
   font-weight: normal; /* 400 Normal (Regular) */
   src: url(./gentiumplus/GentiumBookPlus-Regular.woff2);
-  font-feature-settings: "smcp" 0, "c2sc" 0, "ss01" 0, "ss11" 0, "ss12" 0, "ss04" 0, "ss05" 0, "cv13" 0, "cv17" 0, "cv28" 0, "cv37" 0, "cv43" 0, "cv44" 0, "cv46" 0, "cv47" 0, "cv49" 0, "cv55" 0, "cv57" 0, "cv62" 0, "cv68" 0, "cv20" 0, "cv19" 0, "cv25" 0, "cv69" 0, "ss07" 0, "cv75" 0, "cv79" 0, "cv76" 0, "cv77" 0, "cv70" 0, "cv71" 0, "cv98" 0, "cv80" 0, "cv81" 0, "cv82" 0, "cv84" 0, "cv78" 0, "cv83" 0, "cv14" 0, "cv90" 0, "cv91" 0, "cv92" 0, "subs" 0, "sups" 0, "frac" 0;
-  -moz-font-font-feature-settings: "smcp" 0, "c2sc" 0, "ss01" 0, "ss11" 0, "ss12" 0, "ss04" 0, "ss05" 0, "cv13" 0, "cv17" 0, "cv28" 0, "cv37" 0, "cv43" 0, "cv44" 0, "cv46" 0, "cv47" 0, "cv49" 0, "cv55" 0, "cv57" 0, "cv62" 0, "cv68" 0, "cv20" 0, "cv19" 0, "cv25" 0, "cv69" 0, "ss07" 0, "cv75" 0, "cv79" 0, "cv76" 0, "cv77" 0, "cv70" 0, "cv71" 0, "cv98" 0, "cv80" 0, "cv81" 0, "cv82" 0, "cv84" 0, "cv78" 0, "cv83" 0, "cv14" 0, "cv90" 0, "cv91" 0, "cv92" 0, "subs" 0, "sups" 0, "frac" 0;
-  -webkit-font-feature-settings: "smcp" 0, "c2sc" 0, "ss01" 0, "ss11" 0, "ss12" 0, "ss04" 0, "ss05" 0, "cv13" 0, "cv17" 0, "cv28" 0, "cv37" 0, "cv43" 0, "cv44" 0, "cv46" 0, "cv47" 0, "cv49" 0, "cv55" 0, "cv57" 0, "cv62" 0, "cv68" 0, "cv20" 0, "cv19" 0, "cv25" 0, "cv69" 0, "ss07" 0, "cv75" 0, "cv79" 0, "cv76" 0, "cv77" 0, "cv70" 0, "cv71" 0, "cv98" 0, "cv80" 0, "cv81" 0, "cv82" 0, "cv84" 0, "cv78" 0, "cv83" 0, "cv14" 0, "cv90" 0, "cv91" 0, "cv92" 0, "subs" 0, "sups" 0, "frac" 0;
+  font-feature-settings: %%FONTFEATURES%%;
+  -moz-font-font-feature-settings: %%FONTFEATURES%%;
+  -webkit-font-feature-settings: %%FONTFEATURES%%;
 }
 
 /* italic */
@@ -18,9 +18,9 @@
   font-style: italic;
   font-weight: normal; /* 400 Normal (Regular) */
   src: url(./gentiumplus/GentiumBookPlus-Italic.woff2);
-  font-feature-settings: "smcp" 0, "c2sc" 0, "ss01" 0, "ss11" 0, "ss12" 0, "ss04" 0, "ss05" 0, "cv13" 0, "cv17" 0, "cv28" 0, "cv37" 0, "cv43" 0, "cv44" 0, "cv46" 0, "cv47" 0, "cv49" 0, "cv55" 0, "cv57" 0, "cv62" 0, "cv68" 0, "cv20" 0, "cv19" 0, "cv25" 0, "cv69" 0, "ss07" 0, "cv75" 0, "cv79" 0, "cv76" 0, "cv77" 0, "cv70" 0, "cv71" 0, "cv98" 0, "cv80" 0, "cv81" 0, "cv82" 0, "cv84" 0, "cv78" 0, "cv83" 0, "cv14" 0, "cv90" 0, "cv91" 0, "cv92" 0, "subs" 0, "sups" 0, "frac" 0;
-  -moz-font-font-feature-settings: "smcp" 0, "c2sc" 0, "ss01" 0, "ss11" 0, "ss12" 0, "ss04" 0, "ss05" 0, "cv13" 0, "cv17" 0, "cv28" 0, "cv37" 0, "cv43" 0, "cv44" 0, "cv46" 0, "cv47" 0, "cv49" 0, "cv55" 0, "cv57" 0, "cv62" 0, "cv68" 0, "cv20" 0, "cv19" 0, "cv25" 0, "cv69" 0, "ss07" 0, "cv75" 0, "cv79" 0, "cv76" 0, "cv77" 0, "cv70" 0, "cv71" 0, "cv98" 0, "cv80" 0, "cv81" 0, "cv82" 0, "cv84" 0, "cv78" 0, "cv83" 0, "cv14" 0, "cv90" 0, "cv91" 0, "cv92" 0, "subs" 0, "sups" 0, "frac" 0;
-  -webkit-font-feature-settings: "smcp" 0, "c2sc" 0, "ss01" 0, "ss11" 0, "ss12" 0, "ss04" 0, "ss05" 0, "cv13" 0, "cv17" 0, "cv28" 0, "cv37" 0, "cv43" 0, "cv44" 0, "cv46" 0, "cv47" 0, "cv49" 0, "cv55" 0, "cv57" 0, "cv62" 0, "cv68" 0, "cv20" 0, "cv19" 0, "cv25" 0, "cv69" 0, "ss07" 0, "cv75" 0, "cv79" 0, "cv76" 0, "cv77" 0, "cv70" 0, "cv71" 0, "cv98" 0, "cv80" 0, "cv81" 0, "cv82" 0, "cv84" 0, "cv78" 0, "cv83" 0, "cv14" 0, "cv90" 0, "cv91" 0, "cv92" 0, "subs" 0, "sups" 0, "frac" 0;
+  font-feature-settings: %%FONTFEATURES%%;
+  -moz-font-font-feature-settings: %%FONTFEATURES%%;
+  -webkit-font-feature-settings: %%FONTFEATURES%%;
 }
 
 /* bold */
@@ -29,9 +29,9 @@
   font-style: normal;
   font-weight: bold; /* 700 */
   src: url(./gentiumplus/GentiumBookPlus-Bold.woff2);
-  font-feature-settings: "smcp" 0, "c2sc" 0, "ss01" 0, "ss11" 0, "ss12" 0, "ss04" 0, "ss05" 0, "cv13" 0, "cv17" 0, "cv28" 0, "cv37" 0, "cv43" 0, "cv44" 0, "cv46" 0, "cv47" 0, "cv49" 0, "cv55" 0, "cv57" 0, "cv62" 0, "cv68" 0, "cv20" 0, "cv19" 0, "cv25" 0, "cv69" 0, "ss07" 0, "cv75" 0, "cv79" 0, "cv76" 0, "cv77" 0, "cv70" 0, "cv71" 0, "cv98" 0, "cv80" 0, "cv81" 0, "cv82" 0, "cv84" 0, "cv78" 0, "cv83" 0, "cv14" 0, "cv90" 0, "cv91" 0, "cv92" 0, "subs" 0, "sups" 0, "frac" 0;
-  -moz-font-font-feature-settings: "smcp" 0, "c2sc" 0, "ss01" 0, "ss11" 0, "ss12" 0, "ss04" 0, "ss05" 0, "cv13" 0, "cv17" 0, "cv28" 0, "cv37" 0, "cv43" 0, "cv44" 0, "cv46" 0, "cv47" 0, "cv49" 0, "cv55" 0, "cv57" 0, "cv62" 0, "cv68" 0, "cv20" 0, "cv19" 0, "cv25" 0, "cv69" 0, "ss07" 0, "cv75" 0, "cv79" 0, "cv76" 0, "cv77" 0, "cv70" 0, "cv71" 0, "cv98" 0, "cv80" 0, "cv81" 0, "cv82" 0, "cv84" 0, "cv78" 0, "cv83" 0, "cv14" 0, "cv90" 0, "cv91" 0, "cv92" 0, "subs" 0, "sups" 0, "frac" 0;
-  -webkit-font-feature-settings: "smcp" 0, "c2sc" 0, "ss01" 0, "ss11" 0, "ss12" 0, "ss04" 0, "ss05" 0, "cv13" 0, "cv17" 0, "cv28" 0, "cv37" 0, "cv43" 0, "cv44" 0, "cv46" 0, "cv47" 0, "cv49" 0, "cv55" 0, "cv57" 0, "cv62" 0, "cv68" 0, "cv20" 0, "cv19" 0, "cv25" 0, "cv69" 0, "ss07" 0, "cv75" 0, "cv79" 0, "cv76" 0, "cv77" 0, "cv70" 0, "cv71" 0, "cv98" 0, "cv80" 0, "cv81" 0, "cv82" 0, "cv84" 0, "cv78" 0, "cv83" 0, "cv14" 0, "cv90" 0, "cv91" 0, "cv92" 0, "subs" 0, "sups" 0, "frac" 0;
+  font-feature-settings: %%FONTFEATURES%%;
+  -moz-font-font-feature-settings: %%FONTFEATURES%%;
+  -webkit-font-feature-settings: %%FONTFEATURES%%;
 }
 
 /* bold italic */
@@ -40,7 +40,7 @@
   font-style: italic;
   font-weight: bold; /* 700 */
   src: url(./gentiumplus/GentiumBookPlus-BoldItalic.woff2);
-  font-feature-settings: "smcp" 0, "c2sc" 0, "ss01" 0, "ss11" 0, "ss12" 0, "ss04" 0, "ss05" 0, "cv13" 0, "cv17" 0, "cv28" 0, "cv37" 0, "cv43" 0, "cv44" 0, "cv46" 0, "cv47" 0, "cv49" 0, "cv55" 0, "cv57" 0, "cv62" 0, "cv68" 0, "cv20" 0, "cv19" 0, "cv25" 0, "cv69" 0, "ss07" 0, "cv75" 0, "cv79" 0, "cv76" 0, "cv77" 0, "cv70" 0, "cv71" 0, "cv98" 0, "cv80" 0, "cv81" 0, "cv82" 0, "cv84" 0, "cv78" 0, "cv83" 0, "cv14" 0, "cv90" 0, "cv91" 0, "cv92" 0, "subs" 0, "sups" 0, "frac" 0;
-  -moz-font-font-feature-settings: "smcp" 0, "c2sc" 0, "ss01" 0, "ss11" 0, "ss12" 0, "ss04" 0, "ss05" 0, "cv13" 0, "cv17" 0, "cv28" 0, "cv37" 0, "cv43" 0, "cv44" 0, "cv46" 0, "cv47" 0, "cv49" 0, "cv55" 0, "cv57" 0, "cv62" 0, "cv68" 0, "cv20" 0, "cv19" 0, "cv25" 0, "cv69" 0, "ss07" 0, "cv75" 0, "cv79" 0, "cv76" 0, "cv77" 0, "cv70" 0, "cv71" 0, "cv98" 0, "cv80" 0, "cv81" 0, "cv82" 0, "cv84" 0, "cv78" 0, "cv83" 0, "cv14" 0, "cv90" 0, "cv91" 0, "cv92" 0, "subs" 0, "sups" 0, "frac" 0;
-  -webkit-font-feature-settings: "smcp" 0, "c2sc" 0, "ss01" 0, "ss11" 0, "ss12" 0, "ss04" 0, "ss05" 0, "cv13" 0, "cv17" 0, "cv28" 0, "cv37" 0, "cv43" 0, "cv44" 0, "cv46" 0, "cv47" 0, "cv49" 0, "cv55" 0, "cv57" 0, "cv62" 0, "cv68" 0, "cv20" 0, "cv19" 0, "cv25" 0, "cv69" 0, "ss07" 0, "cv75" 0, "cv79" 0, "cv76" 0, "cv77" 0, "cv70" 0, "cv71" 0, "cv98" 0, "cv80" 0, "cv81" 0, "cv82" 0, "cv84" 0, "cv78" 0, "cv83" 0, "cv14" 0, "cv90" 0, "cv91" 0, "cv92" 0, "subs" 0, "sups" 0, "frac" 0;
+  font-feature-settings: %%FONTFEATURES%%;
+  -moz-font-font-feature-settings: %%FONTFEATURES%%;
+  -webkit-font-feature-settings: %%FONTFEATURES%%;
 }

--- a/webfonts/pankosmia-Gentium_Plus.css
+++ b/webfonts/pankosmia-Gentium_Plus.css
@@ -7,9 +7,9 @@
   font-style: normal;
   font-weight: normal; /* 400 Normal (Regular) */
   src: url(./gentiumplus/GentiumPlus-Regular.woff2);
-  font-feature-settings: "smcp" 0, "c2sc" 0, "ss01" 0, "ss11" 0, "ss12" 0, "ss04" 0, "ss05" 0, "cv13" 0, "cv17" 0, "cv28" 0, "cv37" 0, "cv43" 0, "cv44" 0, "cv46" 0, "cv47" 0, "cv49" 0, "cv55" 0, "cv57" 0, "cv62" 0, "cv68" 0, "cv20" 0, "cv19" 0, "cv25" 0, "cv69" 0, "ss07" 0, "cv75" 0, "cv79" 0, "cv76" 0, "cv77" 0, "cv70" 0, "cv71" 0, "cv98" 0, "cv80" 0, "cv81" 0, "cv82" 0, "cv84" 0, "cv78" 0, "cv83" 0, "cv14" 0, "cv90" 0, "cv91" 0, "cv92" 0, "subs" 0, "sups" 0, "frac" 0;
-  -moz-font-font-feature-settings: "smcp" 0, "c2sc" 0, "ss01" 0, "ss11" 0, "ss12" 0, "ss04" 0, "ss05" 0, "cv13" 0, "cv17" 0, "cv28" 0, "cv37" 0, "cv43" 0, "cv44" 0, "cv46" 0, "cv47" 0, "cv49" 0, "cv55" 0, "cv57" 0, "cv62" 0, "cv68" 0, "cv20" 0, "cv19" 0, "cv25" 0, "cv69" 0, "ss07" 0, "cv75" 0, "cv79" 0, "cv76" 0, "cv77" 0, "cv70" 0, "cv71" 0, "cv98" 0, "cv80" 0, "cv81" 0, "cv82" 0, "cv84" 0, "cv78" 0, "cv83" 0, "cv14" 0, "cv90" 0, "cv91" 0, "cv92" 0, "subs" 0, "sups" 0, "frac" 0;
-  -webkit-font-feature-settings: "smcp" 0, "c2sc" 0, "ss01" 0, "ss11" 0, "ss12" 0, "ss04" 0, "ss05" 0, "cv13" 0, "cv17" 0, "cv28" 0, "cv37" 0, "cv43" 0, "cv44" 0, "cv46" 0, "cv47" 0, "cv49" 0, "cv55" 0, "cv57" 0, "cv62" 0, "cv68" 0, "cv20" 0, "cv19" 0, "cv25" 0, "cv69" 0, "ss07" 0, "cv75" 0, "cv79" 0, "cv76" 0, "cv77" 0, "cv70" 0, "cv71" 0, "cv98" 0, "cv80" 0, "cv81" 0, "cv82" 0, "cv84" 0, "cv78" 0, "cv83" 0, "cv14" 0, "cv90" 0, "cv91" 0, "cv92" 0, "subs" 0, "sups" 0, "frac" 0;
+  font-feature-settings: %%FONTFEATURES%%;
+  -moz-font-font-feature-settings: %%FONTFEATURES%%;
+  -webkit-font-feature-settings: %%FONTFEATURES%%;
 }
 
 /* italic */
@@ -18,9 +18,9 @@
   font-style: italic;
   font-weight: normal; /* 400 Normal (Regular) */
   src: url(./gentiumplus/GentiumPlus-Italic.woff2);
-  font-feature-settings: "smcp" 0, "c2sc" 0, "ss01" 0, "ss11" 0, "ss12" 0, "ss04" 0, "ss05" 0, "cv13" 0, "cv17" 0, "cv28" 0, "cv37" 0, "cv43" 0, "cv44" 0, "cv46" 0, "cv47" 0, "cv49" 0, "cv55" 0, "cv57" 0, "cv62" 0, "cv68" 0, "cv20" 0, "cv19" 0, "cv25" 0, "cv69" 0, "ss07" 0, "cv75" 0, "cv79" 0, "cv76" 0, "cv77" 0, "cv70" 0, "cv71" 0, "cv98" 0, "cv80" 0, "cv81" 0, "cv82" 0, "cv84" 0, "cv78" 0, "cv83" 0, "cv14" 0, "cv90" 0, "cv91" 0, "cv92" 0, "subs" 0, "sups" 0, "frac" 0;
-  -moz-font-font-feature-settings: "smcp" 0, "c2sc" 0, "ss01" 0, "ss11" 0, "ss12" 0, "ss04" 0, "ss05" 0, "cv13" 0, "cv17" 0, "cv28" 0, "cv37" 0, "cv43" 0, "cv44" 0, "cv46" 0, "cv47" 0, "cv49" 0, "cv55" 0, "cv57" 0, "cv62" 0, "cv68" 0, "cv20" 0, "cv19" 0, "cv25" 0, "cv69" 0, "ss07" 0, "cv75" 0, "cv79" 0, "cv76" 0, "cv77" 0, "cv70" 0, "cv71" 0, "cv98" 0, "cv80" 0, "cv81" 0, "cv82" 0, "cv84" 0, "cv78" 0, "cv83" 0, "cv14" 0, "cv90" 0, "cv91" 0, "cv92" 0, "subs" 0, "sups" 0, "frac" 0;
-  -webkit-font-feature-settings: "smcp" 0, "c2sc" 0, "ss01" 0, "ss11" 0, "ss12" 0, "ss04" 0, "ss05" 0, "cv13" 0, "cv17" 0, "cv28" 0, "cv37" 0, "cv43" 0, "cv44" 0, "cv46" 0, "cv47" 0, "cv49" 0, "cv55" 0, "cv57" 0, "cv62" 0, "cv68" 0, "cv20" 0, "cv19" 0, "cv25" 0, "cv69" 0, "ss07" 0, "cv75" 0, "cv79" 0, "cv76" 0, "cv77" 0, "cv70" 0, "cv71" 0, "cv98" 0, "cv80" 0, "cv81" 0, "cv82" 0, "cv84" 0, "cv78" 0, "cv83" 0, "cv14" 0, "cv90" 0, "cv91" 0, "cv92" 0, "subs" 0, "sups" 0, "frac" 0;
+  font-feature-settings: %%FONTFEATURES%%;
+  -moz-font-font-feature-settings: %%FONTFEATURES%%;
+  -webkit-font-feature-settings: %%FONTFEATURES%%;
 }
 
 /* bold */
@@ -29,9 +29,9 @@
   font-style: normal;
   font-weight: bold; /* 700 */
   src: url(./gentiumplus/GentiumPlus-Bold.woff2);
-  font-feature-settings: "smcp" 0, "c2sc" 0, "ss01" 0, "ss11" 0, "ss12" 0, "ss04" 0, "ss05" 0, "cv13" 0, "cv17" 0, "cv28" 0, "cv37" 0, "cv43" 0, "cv44" 0, "cv46" 0, "cv47" 0, "cv49" 0, "cv55" 0, "cv57" 0, "cv62" 0, "cv68" 0, "cv20" 0, "cv19" 0, "cv25" 0, "cv69" 0, "ss07" 0, "cv75" 0, "cv79" 0, "cv76" 0, "cv77" 0, "cv70" 0, "cv71" 0, "cv98" 0, "cv80" 0, "cv81" 0, "cv82" 0, "cv84" 0, "cv78" 0, "cv83" 0, "cv14" 0, "cv90" 0, "cv91" 0, "cv92" 0, "subs" 0, "sups" 0, "frac" 0;
-  -moz-font-font-feature-settings: "smcp" 0, "c2sc" 0, "ss01" 0, "ss11" 0, "ss12" 0, "ss04" 0, "ss05" 0, "cv13" 0, "cv17" 0, "cv28" 0, "cv37" 0, "cv43" 0, "cv44" 0, "cv46" 0, "cv47" 0, "cv49" 0, "cv55" 0, "cv57" 0, "cv62" 0, "cv68" 0, "cv20" 0, "cv19" 0, "cv25" 0, "cv69" 0, "ss07" 0, "cv75" 0, "cv79" 0, "cv76" 0, "cv77" 0, "cv70" 0, "cv71" 0, "cv98" 0, "cv80" 0, "cv81" 0, "cv82" 0, "cv84" 0, "cv78" 0, "cv83" 0, "cv14" 0, "cv90" 0, "cv91" 0, "cv92" 0, "subs" 0, "sups" 0, "frac" 0;
-  -webkit-font-feature-settings: "smcp" 0, "c2sc" 0, "ss01" 0, "ss11" 0, "ss12" 0, "ss04" 0, "ss05" 0, "cv13" 0, "cv17" 0, "cv28" 0, "cv37" 0, "cv43" 0, "cv44" 0, "cv46" 0, "cv47" 0, "cv49" 0, "cv55" 0, "cv57" 0, "cv62" 0, "cv68" 0, "cv20" 0, "cv19" 0, "cv25" 0, "cv69" 0, "ss07" 0, "cv75" 0, "cv79" 0, "cv76" 0, "cv77" 0, "cv70" 0, "cv71" 0, "cv98" 0, "cv80" 0, "cv81" 0, "cv82" 0, "cv84" 0, "cv78" 0, "cv83" 0, "cv14" 0, "cv90" 0, "cv91" 0, "cv92" 0, "subs" 0, "sups" 0, "frac" 0;
+  font-feature-settings: %%FONTFEATURES%%;
+  -moz-font-font-feature-settings: %%FONTFEATURES%%;
+  -webkit-font-feature-settings: %%FONTFEATURES%%;
 }
 
 /* bold italic */
@@ -40,7 +40,7 @@
   font-style: italic;
   font-weight: bold; /* 700 */
   src: url(./gentiumplus/GentiumPlus-BoldItalic.woff2);
-  font-feature-settings: "smcp" 0, "c2sc" 0, "ss01" 0, "ss11" 0, "ss12" 0, "ss04" 0, "ss05" 0, "cv13" 0, "cv17" 0, "cv28" 0, "cv37" 0, "cv43" 0, "cv44" 0, "cv46" 0, "cv47" 0, "cv49" 0, "cv55" 0, "cv57" 0, "cv62" 0, "cv68" 0, "cv20" 0, "cv19" 0, "cv25" 0, "cv69" 0, "ss07" 0, "cv75" 0, "cv79" 0, "cv76" 0, "cv77" 0, "cv70" 0, "cv71" 0, "cv98" 0, "cv80" 0, "cv81" 0, "cv82" 0, "cv84" 0, "cv78" 0, "cv83" 0, "cv14" 0, "cv90" 0, "cv91" 0, "cv92" 0, "subs" 0, "sups" 0, "frac" 0;
-  -moz-font-font-feature-settings: "smcp" 0, "c2sc" 0, "ss01" 0, "ss11" 0, "ss12" 0, "ss04" 0, "ss05" 0, "cv13" 0, "cv17" 0, "cv28" 0, "cv37" 0, "cv43" 0, "cv44" 0, "cv46" 0, "cv47" 0, "cv49" 0, "cv55" 0, "cv57" 0, "cv62" 0, "cv68" 0, "cv20" 0, "cv19" 0, "cv25" 0, "cv69" 0, "ss07" 0, "cv75" 0, "cv79" 0, "cv76" 0, "cv77" 0, "cv70" 0, "cv71" 0, "cv98" 0, "cv80" 0, "cv81" 0, "cv82" 0, "cv84" 0, "cv78" 0, "cv83" 0, "cv14" 0, "cv90" 0, "cv91" 0, "cv92" 0, "subs" 0, "sups" 0, "frac" 0;
-  -webkit-font-feature-settings: "smcp" 0, "c2sc" 0, "ss01" 0, "ss11" 0, "ss12" 0, "ss04" 0, "ss05" 0, "cv13" 0, "cv17" 0, "cv28" 0, "cv37" 0, "cv43" 0, "cv44" 0, "cv46" 0, "cv47" 0, "cv49" 0, "cv55" 0, "cv57" 0, "cv62" 0, "cv68" 0, "cv20" 0, "cv19" 0, "cv25" 0, "cv69" 0, "ss07" 0, "cv75" 0, "cv79" 0, "cv76" 0, "cv77" 0, "cv70" 0, "cv71" 0, "cv98" 0, "cv80" 0, "cv81" 0, "cv82" 0, "cv84" 0, "cv78" 0, "cv83" 0, "cv14" 0, "cv90" 0, "cv91" 0, "cv92" 0, "subs" 0, "sups" 0, "frac" 0;
+  font-feature-settings: %%FONTFEATURES%%;
+  -moz-font-font-feature-settings: %%FONTFEATURES%%;
+  -webkit-font-feature-settings: %%FONTFEATURES%%;
 }

--- a/webfonts/pankosmia-Padauk.css
+++ b/webfonts/pankosmia-Padauk.css
@@ -9,9 +9,9 @@
   src: url(./padauk/Padauk-Regular.woff2);
   unicode-range: U+1000-109F, U+AA60-AA7F, U+A9E0-A9FF, U+116D0-116FF, U+A900-A92F;
   font-display: swap;
-  font-feature-settings: "cv01" 0, "cv02" 0, "cv03" 0, "cv04" 0, "cv05" 0, "cv06" 0, "cv07" 0, "cv09" 0, "cv10" 0, "lldt" 0, "ulon" 0, "utal" 0, "dotc" 1, "nnya" 0, "vtta" 0, "dotr" 0;
-  -moz-font-feature-settings: "cv01" 0, "cv02" 0, "cv03" 0, "cv04" 0, "cv05" 0, "cv06" 0, "cv07" 0, "cv09" 0, "cv10" 0, "lldt" 0, "ulon" 0, "utal" 0, "dotc" 1, "nnya" 0, "vtta" 0, "dotr" 0;
-  -webkit-font-feature-settings: "cv01" 0, "cv02" 0, "cv03" 0, "cv04" 0, "cv05" 0, "cv06" 0, "cv07" 0, "cv09" 0, "cv10" 0, "lldt" 0, "ulon" 0, "utal" 0, "dotc" 1, "nnya" 0, "vtta" 0, "dotr" 0;
+  font-feature-settings: %%FONTFEATURES%%;
+  -moz-font-feature-settings: %%FONTFEATURES%%;
+  -webkit-font-feature-settings: %%FONTFEATURES%%;
 }
 
 /* italic */
@@ -22,9 +22,9 @@
   src: url(./padauk/Padauk-Regular.woff2);
   unicode-range: U+1000-109F, U+AA60-AA7F, U+A9E0-A9FF, U+116D0-116FF, U+A900-A92F;
   font-display: swap;
-  font-feature-settings: "cv01" 0, "cv02" 0, "cv03" 0, "cv04" 0, "cv05" 0, "cv06" 0, "cv07" 0, "cv09" 0, "cv10" 0, "lldt" 0, "ulon" 0, "utal" 0, "dotc" 1, "nnya" 0, "vtta" 0, "dotr" 0;
-  -moz-font-feature-settings: "cv01" 0, "cv02" 0, "cv03" 0, "cv04" 0, "cv05" 0, "cv06" 0, "cv07" 0, "cv09" 0, "cv10" 0, "lldt" 0, "ulon" 0, "utal" 0, "dotc" 1, "nnya" 0, "vtta" 0, "dotr" 0;
-  -webkit-font-feature-settings: "cv01" 0, "cv02" 0, "cv03" 0, "cv04" 0, "cv05" 0, "cv06" 0, "cv07" 0, "cv09" 0, "cv10" 0, "lldt" 0, "ulon" 0, "utal" 0, "dotc" 1, "nnya" 0, "vtta" 0, "dotr" 0;
+  font-feature-settings: %%FONTFEATURES%%;
+  -moz-font-feature-settings: %%FONTFEATURES%%;
+  -webkit-font-feature-settings: %%FONTFEATURES%%;
 }
 
 /* bold */
@@ -35,9 +35,9 @@
   src: url(./padauk/Padauk-Bold.woff2);
   unicode-range: U+1000-109F, U+AA60-AA7F, U+A9E0-A9FF, U+116D0-116FF, U+A900-A92F;
   font-display: swap;
-  font-feature-settings: "cv01" 0, "cv02" 0, "cv03" 0, "cv04" 0, "cv05" 0, "cv06" 0, "cv07" 0, "cv09" 0, "cv10" 0, "lldt" 0, "ulon" 0, "utal" 0, "dotc" 1, "nnya" 0, "vtta" 0, "dotr" 0;
-  -moz-font-feature-settings: "cv01" 0, "cv02" 0, "cv03" 0, "cv04" 0, "cv05" 0, "cv06" 0, "cv07" 0, "cv09" 0, "cv10" 0, "lldt" 0, "ulon" 0, "utal" 0, "dotc" 1, "nnya" 0, "vtta" 0, "dotr" 0;
-  -webkit-font-feature-settings: "cv01" 0, "cv02" 0, "cv03" 0, "cv04" 0, "cv05" 0, "cv06" 0, "cv07" 0, "cv09" 0, "cv10" 0, "lldt" 0, "ulon" 0, "utal" 0, "dotc" 1, "nnya" 0, "vtta" 0, "dotr" 0;
+  font-feature-settings: %%FONTFEATURES%%;
+  -moz-font-feature-settings: %%FONTFEATURES%%;
+  -webkit-font-feature-settings: %%FONTFEATURES%%;
 }
 
 /* bold italic */
@@ -48,7 +48,7 @@
   src: url(./padauk/Padauk-Bold.woff2);
   unicode-range: U+1000-109F, U+AA60-AA7F, U+A9E0-A9FF, U+116D0-116FF, U+A900-A92F;
   font-display: swap;
-  font-feature-settings: "cv01" 0, "cv02" 0, "cv03" 0, "cv04" 0, "cv05" 0, "cv06" 0, "cv07" 0, "cv09" 0, "cv10" 0, "lldt" 0, "ulon" 0, "utal" 0, "dotc" 1, "nnya" 0, "vtta" 0, "dotr" 0;
-  -moz-font-feature-settings: "cv01" 0, "cv02" 0, "cv03" 0, "cv04" 0, "cv05" 0, "cv06" 0, "cv07" 0, "cv09" 0, "cv10" 0, "lldt" 0, "ulon" 0, "utal" 0, "dotc" 1, "nnya" 0, "vtta" 0, "dotr" 0;
-  -webkit-font-feature-settings: "cv01" 0, "cv02" 0, "cv03" 0, "cv04" 0, "cv05" 0, "cv06" 0, "cv07" 0, "cv09" 0, "cv10" 0, "lldt" 0, "ulon" 0, "utal" 0, "dotc" 1, "nnya" 0, "vtta" 0, "dotr" 0;
+  font-feature-settings: %%FONTFEATURES%%;
+  -moz-font-feature-settings: %%FONTFEATURES%%;
+  -webkit-font-feature-settings: %%FONTFEATURES%%;
 }

--- a/webfonts/pankosmia-Padauk_Book.css
+++ b/webfonts/pankosmia-Padauk_Book.css
@@ -9,10 +9,9 @@
   src: url(./padauk/PadaukBook-Regular.woff2);
   unicode-range: U+1000-109F, U+AA60-AA7F, U+A9E0-A9FF, U+116D0-116FF, U+A900-A92F;
   font-display: swap;
-  font-feature-settings: "cv01" 0, "cv02" 0, "cv03" 0, "cv04" 0, "cv05" 0, "cv06" 0, "cv07" 0, "cv09" 0, "cv10" 0, "lldt" 0, "ulon" 0, "utal" 0, "dotc" 1, "nnya" 0, "vtta" 0, "dotr" 0;
-  -moz-font-feature-settings: "cv01" 0, "cv02" 0, "cv03" 0, "cv04" 0, "cv05" 0, "cv06" 0, "cv07" 0, "cv09" 0, "cv10" 0, "lldt" 0, "ulon" 0, "utal" 0, "dotc" 1, "nnya" 0, "vtta" 0, "dotr" 0;
-  -webkit-font-feature-settings: "cv01" 0, "cv02" 0, "cv03" 0, "cv04" 0, "cv05" 0, "cv06" 0, "cv07" 0, "cv09" 0, "cv10" 0, "lldt" 0, "ulon" 0, "utal" 0, "dotc" 1, "nnya" 0, "vtta" 0, "dotr" 0;
-}
+  font-feature-settings: %%FONTFEATURES%%;
+  -moz-font-feature-settings: %%FONTFEATURES%%;
+  -webkit-font-feature-settings: %%FONTFEATURES%%;}
 
 /* italic */
 @font-face {
@@ -22,10 +21,9 @@
   src: url(./padauk/PadaukBook-Regular.woff2);
   unicode-range: U+1000-109F, U+AA60-AA7F, U+A9E0-A9FF, U+116D0-116FF, U+A900-A92F;
   font-display: swap;
-  font-feature-settings: "cv01" 0, "cv02" 0, "cv03" 0, "cv04" 0, "cv05" 0, "cv06" 0, "cv07" 0, "cv09" 0, "cv10" 0, "lldt" 0, "ulon" 0, "utal" 0, "dotc" 1, "nnya" 0, "vtta" 0, "dotr" 0;
-  -moz-font-feature-settings: "cv01" 0, "cv02" 0, "cv03" 0, "cv04" 0, "cv05" 0, "cv06" 0, "cv07" 0, "cv09" 0, "cv10" 0, "lldt" 0, "ulon" 0, "utal" 0, "dotc" 1, "nnya" 0, "vtta" 0, "dotr" 0;
-  -webkit-font-feature-settings: "cv01" 0, "cv02" 0, "cv03" 0, "cv04" 0, "cv05" 0, "cv06" 0, "cv07" 0, "cv09" 0, "cv10" 0, "lldt" 0, "ulon" 0, "utal" 0, "dotc" 1, "nnya" 0, "vtta" 0, "dotr" 0;
-}
+  font-feature-settings: %%FONTFEATURES%%;
+  -moz-font-feature-settings: %%FONTFEATURES%%;
+  -webkit-font-feature-settings: %%FONTFEATURES%%;}
 
 /* bold */
 @font-face {
@@ -35,10 +33,9 @@
   src: url(./padauk/PadaukBook-Bold.woff2);
   unicode-range: U+1000-109F, U+AA60-AA7F, U+A9E0-A9FF, U+116D0-116FF, U+A900-A92F;
   font-display: swap;
-  font-feature-settings: "cv01" 0, "cv02" 0, "cv03" 0, "cv04" 0, "cv05" 0, "cv06" 0, "cv07" 0, "cv09" 0, "cv10" 0, "lldt" 0, "ulon" 0, "utal" 0, "dotc" 1, "nnya" 0, "vtta" 0, "dotr" 0;
-  -moz-font-feature-settings: "cv01" 0, "cv02" 0, "cv03" 0, "cv04" 0, "cv05" 0, "cv06" 0, "cv07" 0, "cv09" 0, "cv10" 0, "lldt" 0, "ulon" 0, "utal" 0, "dotc" 1, "nnya" 0, "vtta" 0, "dotr" 0;
-  -webkit-font-feature-settings: "cv01" 0, "cv02" 0, "cv03" 0, "cv04" 0, "cv05" 0, "cv06" 0, "cv07" 0, "cv09" 0, "cv10" 0, "lldt" 0, "ulon" 0, "utal" 0, "dotc" 1, "nnya" 0, "vtta" 0, "dotr" 0;
-}
+  font-feature-settings: %%FONTFEATURES%%;
+  -moz-font-feature-settings: %%FONTFEATURES%%;
+  -webkit-font-feature-settings: %%FONTFEATURES%%;}
 
 /* bold italic */
 @font-face {
@@ -48,7 +45,6 @@
   src: url(./padauk/PadaukBook-Bold.woff2);
   unicode-range: U+1000-109F, U+AA60-AA7F, U+A9E0-A9FF, U+116D0-116FF, U+A900-A92F;
   font-display: swap;
-  font-feature-settings: "cv01" 0, "cv02" 0, "cv03" 0, "cv04" 0, "cv05" 0, "cv06" 0, "cv07" 0, "cv09" 0, "cv10" 0, "lldt" 0, "ulon" 0, "utal" 0, "dotc" 1, "nnya" 0, "vtta" 0, "dotr" 0;
-  -moz-font-feature-settings: "cv01" 0, "cv02" 0, "cv03" 0, "cv04" 0, "cv05" 0, "cv06" 0, "cv07" 0, "cv09" 0, "cv10" 0, "lldt" 0, "ulon" 0, "utal" 0, "dotc" 1, "nnya" 0, "vtta" 0, "dotr" 0;
-  -webkit-font-feature-settings: "cv01" 0, "cv02" 0, "cv03" 0, "cv04" 0, "cv05" 0, "cv06" 0, "cv07" 0, "cv09" 0, "cv10" 0, "lldt" 0, "ulon" 0, "utal" 0, "dotc" 1, "nnya" 0, "vtta" 0, "dotr" 0;
-}
+  font-feature-settings: %%FONTFEATURES%%;
+  -moz-font-feature-settings: %%FONTFEATURES%%;
+  -webkit-font-feature-settings: %%FONTFEATURES%%;}

--- a/webfonts/pankosmia-Padauk_Book.css
+++ b/webfonts/pankosmia-Padauk_Book.css
@@ -11,7 +11,8 @@
   font-display: swap;
   font-feature-settings: %%FONTFEATURES%%;
   -moz-font-feature-settings: %%FONTFEATURES%%;
-  -webkit-font-feature-settings: %%FONTFEATURES%%;}
+  -webkit-font-feature-settings: %%FONTFEATURES%%;
+}
 
 /* italic */
 @font-face {
@@ -23,7 +24,8 @@
   font-display: swap;
   font-feature-settings: %%FONTFEATURES%%;
   -moz-font-feature-settings: %%FONTFEATURES%%;
-  -webkit-font-feature-settings: %%FONTFEATURES%%;}
+  -webkit-font-feature-settings: %%FONTFEATURES%%;
+}
 
 /* bold */
 @font-face {
@@ -35,7 +37,8 @@
   font-display: swap;
   font-feature-settings: %%FONTFEATURES%%;
   -moz-font-feature-settings: %%FONTFEATURES%%;
-  -webkit-font-feature-settings: %%FONTFEATURES%%;}
+  -webkit-font-feature-settings: %%FONTFEATURES%%;
+}
 
 /* bold italic */
 @font-face {
@@ -47,4 +50,5 @@
   font-display: swap;
   font-feature-settings: %%FONTFEATURES%%;
   -moz-font-feature-settings: %%FONTFEATURES%%;
-  -webkit-font-feature-settings: %%FONTFEATURES%%;}
+  -webkit-font-feature-settings: %%FONTFEATURES%%;
+}


### PR DESCRIPTION
Sync up font css templates with pankosmia_web. (Keep functionality on liminal, pankosmia_web and pithekos the same when all are using the same panksomia_web versions.)